### PR TITLE
Add chocolatey package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 
 ./bin
+
+# Chocolatey
+*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ pull_requests:
 branches:
   only:
     - master
-    - add-choco-package
 clone_folder: c:\gopath\src\github.com\pecigonzalo\docker-machine-vmwareworkstation
 clone_depth: 5
 
@@ -18,7 +17,7 @@ os: Windows Server 2012 R2
 
 environment:
   CHOCOLATEY_TOKEN:
-    secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66
+    secure: TBD
   GOPATH: c:\gopath
   matrix:
   - GOARCH: 386
@@ -32,6 +31,7 @@ init:
 # Build
 
 install:
+  - choco install vmwareworkstation # to have vmrun.exe for unit tests
   - set Path=c:\go\bin;%Path%
   - echo %Path%
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-%GOARCH%.msi
@@ -49,7 +49,7 @@ build_script:
   - ps: cd choco; cpack; cd ..
 
 test_script:
-  - ps: cd choco; .\test.ps1 -cpu x64; cd ..
+  - ps: cd choco; .\test.ps1 -cpu %GOARCH%; cd ..
 
 # Deploy
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ pull_requests:
 branches:
   only:
     - master
+    - add-choco-package
 clone_folder: c:\gopath\src\github.com\pecigonzalo\docker-machine-vmwareworkstation
 clone_depth: 5
 
@@ -16,6 +17,8 @@ clone_depth: 5
 os: Windows Server 2012 R2
 
 environment:
+  CHOCOLATEY_TOKEN:
+    secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66
   GOPATH: c:\gopath
   matrix:
   - GOARCH: 386
@@ -43,8 +46,10 @@ build_script:
   - go vet ./...
   - git rev-parse HEAD
   - go build -i -o ./bin/docker-machine-driver-vmwareworkstation_windows-%GOARCH%.exe ./cmd/
+  - ps: cd choco; cpack; cd ..
 
-test: off
+test_script:
+  - ps: cd choco; .\test.ps1 -cpu x64; cd ..
 
 # Deploy
 artifacts:
@@ -58,3 +63,13 @@ deploy:
   on:
     branch: master                 # release from master branch only
     appveyor_repo_tag: true        # deploy on tag push only
+
+deploy_script:
+  - ps: >-
+      Write-Host $env:APPVEYOR_REPO_TAG ;
+      if($env:APPVEYOR_REPO_BRANCH -eq 'master' -And $env:APPVEYOR_REPO_TAG -eq 'true') {
+        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$') ;
+        cd choco ;
+        choco apiKey -k $env:CHOCOLATEY_TOKEN -source https://chocolatey.org/ ;
+        choco push docker-machine-vmwareworkstation.$version.nupkg
+      }

--- a/choco/docker-machine-vmwareworkstation.nuspec
+++ b/choco/docker-machine-vmwareworkstation.nuspec
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>docker-machine-vmwareworkstation</id>
+    <title>docker-machine-vmwareworkstation</title>
+    <version>1.0.0</version>
+    <authors>Gonzalo Peci</authors>
+    <owners>StefanScherer</owners>
+    <summary>VMWare Workstation driver for Docker Machine</summary>
+    <description>Machine lets you create Docker hosts on your computer, on cloud providers, and inside your own data center. It creates servers, installs Docker on them, then configures the Docker client to talk to them.
+    </description>
+    <dependencies>
+      <dependency id="docker-machine" version="0.5.5" />
+    </dependencies>
+    <projectUrl>https://github.com/pecigonzalo/docker-machine-vmwareworkstation</projectUrl>
+    <packageSourceUrl>https://github.com/pecigonzalo/docker-machine-vmwareworkstation</packageSourceUrl>
+    <projectSourceUrl>https://github.com/pecigonzalo/docker-machine-vmwareworkstation</projectSourceUrl>
+    <docsUrl>https://github.com/pecigonzalo/docker-machine-vmwareworkstation#usage</docsUrl>
+    <bugTrackerUrl>https://github.com/pecigonzalo/docker-machine-vmwareworkstation/issues</bugTrackerUrl>
+    <iconUrl>https://raw.githubusercontent.com/docker/machine/master/docs/img/logo.png</iconUrl>
+    <licenseUrl>https://github.com/pecigonzalo/docker-machine-vmwareworkstation/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>docker-machine docker vmware workstation</tags>
+    <releaseNotes>https://github.com/pecigonzalo/docker-machine-vmwareworkstation/blob/master/CHANGELOG.md</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/choco/docker-machine-vmwareworkstation.nuspec
+++ b/choco/docker-machine-vmwareworkstation.nuspec
@@ -3,9 +3,9 @@
   <metadata>
     <id>docker-machine-vmwareworkstation</id>
     <title>docker-machine-vmwareworkstation</title>
-    <version>1.0.0</version>
-    <authors>Gonzalo Peci</authors>
-    <owners>StefanScherer</owners>
+    <version>1.0.10</version>
+    <authors>Gonzalo Peci, StefanScherer</authors>
+    <owners>Gonzalo Peci</owners>
     <summary>VMWare Workstation driver for Docker Machine</summary>
     <description>Machine lets you create Docker hosts on your computer, on cloud providers, and inside your own data center. It creates servers, installs Docker on them, then configures the Docker client to talk to them.
     </description>

--- a/choco/test.ps1
+++ b/choco/test.ps1
@@ -15,7 +15,6 @@ $ErrorActionPreference = "Stop"
 if ($env:APPVEYOR_BUILD_VERSION) {
   # run in CI
   $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
-  $version = "$version.0"
 } else {
   # run manually
   [xml]$spec = Get-Content docker-machine-vmwareworkstation.nuspec
@@ -28,7 +27,7 @@ if ($env:APPVEYOR_BUILD_VERSION) {
 "TEST: Version $version in docker-machine-vmwareworkstation.nuspec file should match"
 [xml]$spec = Get-Content docker-machine-vmwareworkstation.nuspec
 if ($spec.package.metadata.version.CompareTo($version)) {
-  Write-Error "FAIL: rong version in nuspec file!"
+  Write-Error "FAIL: Wrong version in nuspec file!"
 }
 
 "TEST: Package should contain only install script"

--- a/choco/test.ps1
+++ b/choco/test.ps1
@@ -21,9 +21,6 @@ if ($env:APPVEYOR_BUILD_VERSION) {
   $version = $spec.package.metadata.version
 }
 
-"TEST: Installation of docker-machine should work"
-. choco install -y docker-machine
-
 "TEST: Version $version in docker-machine-vmwareworkstation.nuspec file should match"
 [xml]$spec = Get-Content docker-machine-vmwareworkstation.nuspec
 if ($spec.package.metadata.version.CompareTo($version)) {
@@ -39,7 +36,7 @@ if ($zip.Entries.Count -ne 5) {
 $zip.Dispose()
 
 "TEST: Installation of package should work"
-. choco install -y docker-machine-vmwareworkstation $options -source .
+. choco install -y docker-machine-vmwareworkstation $options -source "'.;https://chocolatey.org/api/v2/'"
 
 "TEST: Create a machine with driver vmwareworkstation should work"
 try {

--- a/choco/test.ps1
+++ b/choco/test.ps1
@@ -1,0 +1,57 @@
+param(
+  [string]$cpu
+)
+
+if (!$cpu) {
+  $cpu = "x64"
+}
+if ($cpu -eq "x86") {
+  $options = "-forcex86"
+}
+
+"Running tests for $cpu"
+$ErrorActionPreference = "Stop"
+
+if ($env:APPVEYOR_BUILD_VERSION) {
+  # run in CI
+  $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
+  $version = "$version.0"
+} else {
+  # run manually
+  [xml]$spec = Get-Content docker-machine-vmwareworkstation.nuspec
+  $version = $spec.package.metadata.version
+}
+
+"TEST: Installation of docker-machine should work"
+. choco install -y docker-machine
+
+"TEST: Version $version in docker-machine-vmwareworkstation.nuspec file should match"
+[xml]$spec = Get-Content docker-machine-vmwareworkstation.nuspec
+if ($spec.package.metadata.version.CompareTo($version)) {
+  Write-Error "FAIL: rong version in nuspec file!"
+}
+
+"TEST: Package should contain only install script"
+Add-Type -assembly "system.io.compression.filesystem"
+$zip = [IO.Compression.ZipFile]::OpenRead("$pwd\docker-machine-vmwareworkstation.$version.nupkg")
+if ($zip.Entries.Count -ne 5) {
+  Write-Error "FAIL: Wrong count in nupkg!"
+}
+$zip.Dispose()
+
+"TEST: Installation of package should work"
+. choco install -y docker-machine-vmwareworkstation $options -source .
+
+"TEST: Create a machine with driver vmwareworkstation should work"
+try {
+  . docker-machine create -d vmwareworkstation test
+} catch {
+}
+if (! (Test-Path $env:USERPROFILE\.docker\machine\machines\test)) {
+  Write-Error "FAIL: Machine directory is missing"
+}
+
+"TEST: Uninstall show remove the binary"
+. choco uninstall -y docker-machine-vmwareworkstation
+
+"TEST: Finished"

--- a/choco/test.ps1
+++ b/choco/test.ps1
@@ -3,9 +3,9 @@ param(
 )
 
 if (!$cpu) {
-  $cpu = "x64"
+  $cpu = "amd64"
 }
-if ($cpu -eq "x86") {
+if ($cpu -eq "386") {
   $options = "-forcex86"
 }
 

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
 $packageName    = 'docker-machine-vmwareworkstation'
 $driverName     = 'docker-machine-driver-vmwareworkstation'
-$url            = 'https://github.com/pecigonzalo/docker-machine-vmwareworkstation/releases/download/v1.0.0/docker-machine-driver-vmwareworkstation.exe'
-$checksum       = '56e48f38cd34a277e5c51ec98bb3ccea'
-$url64          = 'https://github.com/pecigonzalo/docker-machine-vmwareworkstation/releases/download/v1.0.0/docker-machine-driver-vmwareworkstation.exe'
-$checksum64     = '56e48f38cd34a277e5c51ec98bb3ccea'
+$url            = 'https://github.com/pecigonzalo/docker-machine-vmwareworkstation/releases/download/v1.0.10/docker-machine-driver-vmwareworkstation_windows-386.exe'
+$checksum       = 'TBD'
+$url64          = 'https://github.com/pecigonzalo/docker-machine-vmwareworkstation/releases/download/v1.0.10/docker-machine-driver-vmwareworkstation_windows-amd64.exe'
+$checksum64     = 'TBD'
 $checksumType   = 'md5'
 $checksumType64 = 'md5'
 

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -1,0 +1,17 @@
+$packageName    = 'docker-machine-vmwareworkstation'
+$driverName     = 'docker-machine-driver-vmwareworkstation'
+$url            = 'https://github.com/pecigonzalo/docker-machine-vmwareworkstation/releases/download/v1.0.0/docker-machine-driver-vmwareworkstation.exe'
+$checksum       = '56e48f38cd34a277e5c51ec98bb3ccea'
+$url64          = 'https://github.com/pecigonzalo/docker-machine-vmwareworkstation/releases/download/v1.0.0/docker-machine-driver-vmwareworkstation.exe'
+$checksum64     = '56e48f38cd34a277e5c51ec98bb3ccea'
+$checksumType   = 'md5'
+$checksumType64 = 'md5'
+
+$toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$packageDir  = "$(Split-Path -parent $toolsDir)"
+$installDir  = Join-Path "$packageDir" "bin"
+$installBin  = "${driverName}.exe"
+$installPath = Join-Path "$installDir" "$installBin"
+
+New-Item -ItemType Directory -Force -Path "$installDir"
+Get-ChocolateyWebFile "$packageName" "$installPath" "$url" "$url64" -checksum "$checksum" -checksumType "$checksumType" -checksum64 "$checksum64" -checksumType64 "$checksumType64"


### PR DESCRIPTION
This is a first rough version integrating the choco package into the same repo and appveyor.yml.

There are some parts that still have to be improved and I'm not sure how to handle all the deployments in one single appveyor build.

If the choco package will be pushed to review it should be possible to deploy it again with the same version number. So my current idea is to cut off the last number of the appveyor build number and use "1.0.0.build" in the appveyor.yml. But then we also should deploy only a 1.0.0 to github releases. 

After a github release the choco install script must be updated to have the current download link and md5/sha1 checksum of the binary. A change should be pushed back to github (which is possible with a `[ci skip]` comment to suppress a further appveyor build.)

Perhaps it is still an easier way to have two repos, one for the go sources and one for the choco package. I'm not sure at the moment.

I'll use the comment function to mark some other lines in the code that should be polished.
